### PR TITLE
Disable version check from master branch

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -46,6 +46,7 @@ jobs:
         with:
           fetch-depth: 0
       - name: Check version bump and set versions as envvar
+        if: github.ref != 'refs/heads/master'
         run: |
           SEMVER_PATTERN="([0-9]+)\.([0-9]+)\.([0-9]+)"
           VERSION=$(echo -n $(git diff origin/${{ github.base_ref }} -G '__version__' app_store_scraper/__version__.py))

--- a/app_store_scraper/__version__.py
+++ b/app_store_scraper/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "app-store-scraper"
-__version__ = "0.2.3"
+__version__ = "0.2.4"
 __description__ = "Single API ☝ App Store Review Scraper 🧹"
 __author__ = "Eric Lim"
 __url__ = "https://github.com/cowboy-bebug/app-store-scraper"


### PR DESCRIPTION
This PR is about fixing broken ci.

Changes:
- Fixed the step to check for version bump by disabling it if triggered from master branch