### PR TITLE
Retry too many requests

### DIFF
--- a/app_store_scraper/__version__.py
+++ b/app_store_scraper/__version__.py
@@ -1,5 +1,5 @@
 __title__ = "app-store-scraper"
-__version__ = "0.3.3"
+__version__ = "0.3.4"
 __description__ = "Single API ☝ App Store Review Scraper 🧹"
 __author__ = "Eric Lim"
 __url__ = "https://github.com/cowboy-bebug/app-store-scraper"

--- a/app_store_scraper/base.py
+++ b/app_store_scraper/base.py
@@ -112,7 +112,7 @@ class Base:
         params=None,
         total=3,
         backoff_factor=3,
-        status_forcelist=[404],
+        status_forcelist=[404, 429],
     ) -> requests.Response:
         retries = Retry(
             total=total,


### PR DESCRIPTION
This PR is about handling `429 Too Many Requests` response status code (supersedes #22). The App Store was kind to return `429` which we can use to retry on:
<img width="846" alt="Screen Shot 2020-10-23 at 11 58 06 AM" src="https://user-images.githubusercontent.com/6591791/96938493-0a8f3f80-1527-11eb-85cc-e7064ca769d9.png">

Changes:
- Added `429` in `status_forcelist` to retry
- Bumped minor version