### PR TITLE
Force tag

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -126,6 +126,6 @@ jobs:
           version=$(echo "$version" | sed -E "s/.*\+__version__.*([0-9]+\.[0-9]+\.[0-9]+).+/\1/")
           if [ "$version" != "" ]; then
             echo "Create and push v$version tag"
-            git tag v"$version"
+            git tag -f v"$version"
             git push origin v"$version"
           fi


### PR DESCRIPTION
This PR is to make `git tag` in ci/cd idempotent.

Changes:
- Use `git tag -f`